### PR TITLE
Test fix for bfb installer

### DIFF
--- a/platform/mellanox/sonic-bfb-installer.sh
+++ b/platform/mellanox/sonic-bfb-installer.sh
@@ -31,7 +31,7 @@ bfb_install_call(){
     #Example:sudo bfb-install -b <full path to image> -r rshim<id>
     local result_file=$(mktemp "/tmp/result_file.XXXXX")
     trap "rm -f $result_file" EXIT
-    local cmd="timeout 300s bfb-install -b $2 -r $1 $appendix"
+    local cmd="timeout 600s bfb-install -b $2 -r $1 $appendix"
     echo "Installing bfb image on DPU connected to $1 using $cmd"
     local indicator="$1:"
     eval "$cmd" > "$result_file" 2>&1 > >(while IFS= read -r line; do echo "$indicator $line"; done > "$result_file")

--- a/platform/mellanox/sonic-bfb-installer.sh
+++ b/platform/mellanox/sonic-bfb-installer.sh
@@ -127,7 +127,7 @@ main(){
             echo "${dev_names_det[@]}"
         else
             IFS=',' read -ra dev_names <<< "$rshim_dev"
-            validate_rshim $dev_names
+            validate_rshim ${dev_names[@]}
         fi
     fi
     trap 'kill_ch_procs' SIGINT SIGTERM SIGHUP
@@ -148,7 +148,7 @@ kill_all_descendant_procs() {
         done
     fi
     if [[ "$self_kill" == true ]]; then
-        kill -15 "$pid" > /dev/null 2>&1
+        kill -9 "$pid" > /dev/null 2>&1
     fi
 }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Test fix for the bfb installer script
The `sonic-bfb-installer` script is fixed in two ways:

- The validate_rshim function was validating only the first element in the list provided when rshim interface was provided manually instead of the whole list
- `SIGKILL` signal is sent instead of `SIGTERM` for killing processes which have been started by the script

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

