### PR TITLE
[202311] Added debug messages for DNS

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -412,6 +412,22 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
 	lsof                    \
 	sysstat
 
+filename="$FILESYSTEM_ROOT/sbin/resolvconf"
+sudo sed -i '/report_err \"Run lock held by another process for longer than $LOCK_WAIT_S seconds\"; exit 1; /a \    echo \"${MYNAME} Run lock obtained by PID $$, PPID $PPID\" >&2 ;' $FILESYSTEM_ROOT/sbin/resolvconf
+sudo sed -i '/: >| \"$ENABLE_UPDATES_FLAGFILE\" || exit 1/c\	: >| \"$ENABLE_UPDATES_FLAGFILE\" || { report_err \"Unable to create ENABLE_UPDATES_FLAGFILE\"; exit 1 ; }' $FILESYSTEM_ROOT/sbin/resolvconf
+sudo sed -i '/rm -f "$ENABLE_UPDATES_FLAGFILE" || exit 1/c\	rm -f \"$ENABLE_UPDATES_FLAGFILE\" || { report_err \"Unable to remove ENABLE_UPDATES_FLAGFILE\"; exit 1 ; }' $FILESYSTEM_ROOT/sbin/resolvconf
+sudo sed -i '/rm -f "$ENABLE_UPDATES_FLAGFILE" || exit 1/c\	rm -f \"$ENABLE_UPDATES_FLAGFILE\" || { report_err \"Unable to remove ENABLE_UPDATES_FLAGFILE\"; exit 1 ; }' $FILESYSTEM_ROOT/sbin/resolvconf
+repl_text="{report_err \"ENABLE_UPDATES_FLAGFILE does not exist\"; exit 1;}"
+sudo awk -v replacement="$repl_text" '
+    {
+        count += gsub(/exit 1/, "exit 1")
+        if (count > 11 && sub(/exit 1/, replacement)){
+            count = -999
+        }
+        print
+    }
+    ' "$filename" > temp_file && sudo mv temp_file "$filename"
+chmod +x /sbin/resolvconf
 # default rsyslog version is 8.2110.0 which has a bug on log rate limit,
 # use backport version
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -t bullseye-backports -y install rsyslog

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -416,7 +416,7 @@ filename="$FILESYSTEM_ROOT/sbin/resolvconf"
 sudo sed -i '/report_err \"Run lock held by another process for longer than $LOCK_WAIT_S seconds\"; exit 1; /a \    echo \"${MYNAME} Run lock obtained by PID $$, PPID $PPID\" >&2 ;' $filename
 sudo sed -i '/: >| \"$ENABLE_UPDATES_FLAGFILE\" || exit 1/c\	: >| \"$ENABLE_UPDATES_FLAGFILE\" || { report_err \"Unable to create ENABLE_UPDATES_FLAGFILE\"; exit 1 ; }' $filename
 sudo sed -i '/rm -f "$ENABLE_UPDATES_FLAGFILE" || exit 1/c\	rm -f \"$ENABLE_UPDATES_FLAGFILE\" || { report_err \"Unable to remove ENABLE_UPDATES_FLAGFILE\"; exit 1 ; }' $filename
-repl_text="{report_err \"ENABLE_UPDATES_FLAGFILE does not exist\"; exit 1;}"
+repl_text="{ report_err \"ENABLE_UPDATES_FLAGFILE does not exist\"; exit 1; }"
 sudo awk -v replacement="$repl_text" '
     {
         count += gsub(/exit 1/, "exit 1")

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -427,7 +427,7 @@ sudo awk -v replacement="$repl_text" '
         print
     }
     ' "$filename" > temp_file && sudo mv temp_file "$filename"
-chmod +x /sbin/resolvconf
+chmod +x $filename
 # default rsyslog version is 8.2110.0 which has a bug on log rate limit,
 # use backport version
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -t bullseye-backports -y install rsyslog

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -416,7 +416,6 @@ filename="$FILESYSTEM_ROOT/sbin/resolvconf"
 sudo sed -i '/report_err \"Run lock held by another process for longer than $LOCK_WAIT_S seconds\"; exit 1; /a \    echo \"${MYNAME} Run lock obtained by PID $$, PPID $PPID\" >&2 ;' $filename
 sudo sed -i '/: >| \"$ENABLE_UPDATES_FLAGFILE\" || exit 1/c\	: >| \"$ENABLE_UPDATES_FLAGFILE\" || { report_err \"Unable to create ENABLE_UPDATES_FLAGFILE\"; exit 1 ; }' $filename
 sudo sed -i '/rm -f "$ENABLE_UPDATES_FLAGFILE" || exit 1/c\	rm -f \"$ENABLE_UPDATES_FLAGFILE\" || { report_err \"Unable to remove ENABLE_UPDATES_FLAGFILE\"; exit 1 ; }' $filename
-sudo sed -i '/rm -f "$ENABLE_UPDATES_FLAGFILE" || exit 1/c\	rm -f \"$ENABLE_UPDATES_FLAGFILE\" || { report_err \"Unable to remove ENABLE_UPDATES_FLAGFILE\"; exit 1 ; }' $filename
 repl_text="{report_err \"ENABLE_UPDATES_FLAGFILE does not exist\"; exit 1;}"
 sudo awk -v replacement="$repl_text" '
     {

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -413,10 +413,10 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
 	sysstat
 
 filename="$FILESYSTEM_ROOT/sbin/resolvconf"
-sudo sed -i '/report_err \"Run lock held by another process for longer than $LOCK_WAIT_S seconds\"; exit 1; /a \    echo \"${MYNAME} Run lock obtained by PID $$, PPID $PPID\" >&2 ;' $FILESYSTEM_ROOT/sbin/resolvconf
-sudo sed -i '/: >| \"$ENABLE_UPDATES_FLAGFILE\" || exit 1/c\	: >| \"$ENABLE_UPDATES_FLAGFILE\" || { report_err \"Unable to create ENABLE_UPDATES_FLAGFILE\"; exit 1 ; }' $FILESYSTEM_ROOT/sbin/resolvconf
-sudo sed -i '/rm -f "$ENABLE_UPDATES_FLAGFILE" || exit 1/c\	rm -f \"$ENABLE_UPDATES_FLAGFILE\" || { report_err \"Unable to remove ENABLE_UPDATES_FLAGFILE\"; exit 1 ; }' $FILESYSTEM_ROOT/sbin/resolvconf
-sudo sed -i '/rm -f "$ENABLE_UPDATES_FLAGFILE" || exit 1/c\	rm -f \"$ENABLE_UPDATES_FLAGFILE\" || { report_err \"Unable to remove ENABLE_UPDATES_FLAGFILE\"; exit 1 ; }' $FILESYSTEM_ROOT/sbin/resolvconf
+sudo sed -i '/report_err \"Run lock held by another process for longer than $LOCK_WAIT_S seconds\"; exit 1; /a \    echo \"${MYNAME} Run lock obtained by PID $$, PPID $PPID\" >&2 ;' $filename
+sudo sed -i '/: >| \"$ENABLE_UPDATES_FLAGFILE\" || exit 1/c\	: >| \"$ENABLE_UPDATES_FLAGFILE\" || { report_err \"Unable to create ENABLE_UPDATES_FLAGFILE\"; exit 1 ; }' $filename
+sudo sed -i '/rm -f "$ENABLE_UPDATES_FLAGFILE" || exit 1/c\	rm -f \"$ENABLE_UPDATES_FLAGFILE\" || { report_err \"Unable to remove ENABLE_UPDATES_FLAGFILE\"; exit 1 ; }' $filename
+sudo sed -i '/rm -f "$ENABLE_UPDATES_FLAGFILE" || exit 1/c\	rm -f \"$ENABLE_UPDATES_FLAGFILE\" || { report_err \"Unable to remove ENABLE_UPDATES_FLAGFILE\"; exit 1 ; }' $filename
 repl_text="{report_err \"ENABLE_UPDATES_FLAGFILE does not exist\"; exit 1;}"
 sudo awk -v replacement="$repl_text" '
     {
@@ -427,7 +427,7 @@ sudo awk -v replacement="$repl_text" '
         print
     }
     ' "$filename" > temp_file && sudo mv temp_file "$filename"
-chmod +x $filename
+sudo chmod +x $filename
 # default rsyslog version is 8.2110.0 which has a bug on log rate limit,
 # use backport version
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -t bullseye-backports -y install rsyslog


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR is created to add debug messages to the DNS resolvconf package files

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
By using the sed command, added new debug messages in the `/sbin/resovlconf` file

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

