### PR TITLE
[Mellanox][Smartswitch] Use of the DPU TTY tool for communication

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn4280-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/platform.json
@@ -653,6 +653,10 @@
             "interface": {
                 "Ethernet224": "Ethernet0"
             },
+            "serial-console": {
+                "device": "ttyUSB0",
+                "baud-rate": "115200"
+            },
             "rshim_info": "rshim0",
             "bus_info": "0000:08:00.0"
         },
@@ -660,6 +664,10 @@
             "midplane_interface": "dpu1",
             "interface": {
                 "Ethernet232": "Ethernet0"
+            },
+            "serial-console": {
+                "device": "ttyUSB1",
+                "baud-rate": "115200"
             },
             "rshim_info": "rshim1",
             "bus_info": "0000:07:00.0"
@@ -669,6 +677,10 @@
             "interface": {
                 "Ethernet240": "Ethernet0"
             },
+            "serial-console": {
+                "device": "ttyUSB2",
+                "baud-rate": "115200"
+            },
             "rshim_info": "rshim2",
             "bus_info": "0000:01:00.0"
         },
@@ -676,6 +688,10 @@
             "midplane_interface": "dpu3",
             "interface": {
                 "Ethernet248": "Ethernet0"
+            },
+            "serial-console": {
+                "device": "ttyUSB3",
+                "baud-rate": "115200"
             },
             "rshim_info": "rshim3",
             "bus_info": "0000:02:00.0"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The `dpu_tty.py` cli tool requires some platform specific configuration for communication to DPU using picocom. The corresponding configuration is added to the platform.json to enable this tool for the smartswitch
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

