### PR TITLE
[Smartswtich] Add only necessary information for DPUS in smartswitch

### DIFF
--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -92,14 +92,17 @@ def generate_t1_smartswitch_switch_sample_config(data, ss_config):
         }
     }
     dhcp_server_ports = {}
+    dpu_midplane_dict = {}
 
     for dpu_name in natsorted(ss_config.get('DPUS', {})):
         midplane_interface = ss_config['DPUS'][dpu_name]['midplane_interface']
+        dpu_midplane_dict[dpu_name] = {}
+        dpu_midplane_dict[dpu_name]['midplane_interface'] = midplane_interface
         dpu_id = int(midplane_interface.replace('dpu', ''))
         dhcp_server_ports['{}|{}'.format(bridge_name, midplane_interface)] = {'ips': ['{}.{}'.format(mpbr_prefix, dpu_id + 1)]}
 
     if dhcp_server_ports:
-        data['DPUS'] = ss_config['DPUS']
+        data['DPUS'] = dpu_midplane_dict
 
         data['FEATURE'] = {
             "dhcp_relay": {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently the complete `DPUS` section in the platform.json is copied to the CONFIG_DB, leading to yang validation failures if we add any additional information which is irrelevant for CONFIG_DB. 
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added only `midplane_interface` key from the `DPUS` section in the platform.json

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

