### PR TITLE
[Mellanox] Query PSU fan speed only on presence

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -258,11 +258,10 @@ class PsuFan(MlnxFan):
             return False
 
     def get_speed(self):
-        if self.get_presence():
-            return super().get_speed()
-        logger.log_notice(f"No PSU presence detected, returning default value for {self._name}")
-        return 0
-
+        if not self.get_presence():
+            logger.log_notice(f"No PSU presence detected, returning default value for {self._name}")
+            return 0
+        return super().get_speed()
 
 class Fan(MlnxFan):
     """Platform-specific Fan class"""

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -1,6 +1,7 @@
 #
-# Copyright (c) 2019-2023 NVIDIA CORPORATION & AFFILIATES.
-# Apache-2.0
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -255,6 +256,12 @@ class PsuFan(MlnxFan):
         except Exception as e:
             logger.log_error('Failed to set PSU FAN speed - {}'.format(e))
             return False
+
+    def get_speed(self):
+        if self.get_presence():
+            return super().get_speed()
+        logger.log_notice(f"No PSU presence detected, returning default value for {self._name}")
+        return 0
 
 
 class Fan(MlnxFan):

--- a/platform/mellanox/mlnx-platform-api/tests/test_fan_api.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_fan_api.py
@@ -1,6 +1,7 @@
 #
-# Copyright (c) 2020-2023 NVIDIA CORPORATION & AFFILIATES.
-# Apache-2.0
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2020-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 import os
 import pytest
 import subprocess
@@ -155,3 +157,8 @@ class TestFan:
         subprocess.check_call = MagicMock()
         utils.read_str_from_file = MagicMock(side_effect=RuntimeError(''))
         assert not fan.set_speed(60)
+        fan.get_presence = MagicMock(return_value=False)
+        assert fan.get_speed() == 0
+        fan.get_presence = MagicMock(return_value=True)
+        utils.read_int_from_file = MagicMock(return_value=60)
+        assert fan.get_speed() == 100


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The `PsuFan` in Mellanox platform queries for fan speed even though the relevant sysfs files do not exist. In `psud` the speed is already overwritten on presence, since the current implementation generates an error log, it is changed to query speed only on PSU presence and return 0 if there is no presence (Previously returned default value)
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Check presence using `get_presence` api and return fan speed only if it returns True

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

