### PR TITLE
[Smartswitch] Fix sensors file for Smartswitch

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn4280-r0/sensors.conf
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/sensors.conf
@@ -1,41 +1,13 @@
-###########################################################################
-# Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+##################################################################################
+# Copyright (c) 2019 - 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Platform specific sensors config for SN4280
-###########################################################################
+##################################################################################
 
 # Temperature sensors
 bus "i2c-2" "i2c-1-mux (chan_id 1)"
     chip "mlxsw-i2c-*-48"
         label temp1 "Ambient ASIC Temp"
-        ignore temp2
-        ignore temp3
-        ignore temp4
-        ignore temp5
-        ignore temp6
-        ignore temp7
-        ignore temp8
-        ignore temp9
-        ignore temp10
-        ignore temp11
-        ignore temp12
-        ignore temp13
-        ignore temp14
-        ignore temp15
-        ignore temp16
-        ignore temp17
-        ignore temp18
-        ignore temp19
-        ignore temp20
-        ignore temp21
-        ignore temp22
-        ignore temp23
-        ignore temp24
-        ignore temp25
-        ignore temp26
-        ignore temp27
-        ignore temp28
-        ignore temp29
 
 bus "i2c-7" "i2c-1-mux (chan_id 6)"
     chip "tmp102-i2c-*-49"
@@ -441,7 +413,7 @@ bus "i2c-21" "i2c-1-mux (chan_id 20)"
         ignore curr4
     chip "xdpe12284-i2c-21-6A"
         label in1 "PMIC-13 12V DPU4 VDD_CPU (in1)"
-        label in2 "PMIC-13 DPU4 VDD_CPU (out)"
+        label in2 "PMIC-13 DPU4 VDD_CPU (out)" 
         ignore in3 
         ignore in4 
         label temp1 "PMIC-13 DPU4 VDD_CPU Temp 1"
@@ -456,7 +428,7 @@ bus "i2c-21" "i2c-1-mux (chan_id 20)"
         ignore curr4
     chip "mp2975-i2c-21-6A"
         label in1 "PMIC-13 12V DPU4 VDD_CPU (in1)"
-        label in2 "PMIC-13 DPU4 VDD_CPU (out)"
+        label in2 "PMIC-13 DPU4 VDD_CPU (out)" 
         ignore in3 
         ignore in4 
         label temp1 "PMIC-13 DPU4 VDD_CPU Temp 1"
@@ -561,5 +533,5 @@ chip "nvme-pci-*"
     ignore temp2
     ignore temp3
 
-chip "00000a00400-mdio-*"
-   label temp1 "PHY TEMP"
+chip "*-mdio-*"
+   ignore temp1

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/sensors.conf
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/sensors.conf
@@ -1,5 +1,5 @@
 ##################################################################################
-# Copyright (c) 2019 - 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024 - 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Platform specific sensors config for SN4280
 ##################################################################################
@@ -8,6 +8,34 @@
 bus "i2c-2" "i2c-1-mux (chan_id 1)"
     chip "mlxsw-i2c-*-48"
         label temp1 "Ambient ASIC Temp"
+        ignore temp2
+        ignore temp3
+        ignore temp4
+        ignore temp5
+        ignore temp6
+        ignore temp7
+        ignore temp8
+        ignore temp9
+        ignore temp10
+        ignore temp11
+        ignore temp12
+        ignore temp13
+        ignore temp14
+        ignore temp15
+        ignore temp16
+        ignore temp17
+        ignore temp18
+        ignore temp19
+        ignore temp20
+        ignore temp21
+        ignore temp22
+        ignore temp23
+        ignore temp24
+        ignore temp25
+        ignore temp26
+        ignore temp27
+        ignore temp28
+        ignore temp29
 
 bus "i2c-7" "i2c-1-mux (chan_id 6)"
     chip "tmp102-i2c-*-49"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
As the mdio sensor will be ignored since we are not using that sensor, the latest configuration has to be updated to sensors.conf in the platform for smartswitch
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Update `sensors.conf` in the x86_64-nvidia_sn4280-r0 platform folder

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

