### PR TITLE
[Mellanox] Interface related changes for DPU

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn4280-r0/pcie.yaml
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/pcie.yaml
@@ -230,17 +230,64 @@
   id: '1467'
   name: 'Host bridge: Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh)
     Data Fabric: Device 18h; Function 7'
+- bus: '01'
+  dev: '00'
+  fn: '0'
+  id: a2dc
+  name: 'Ethernet controller: Mellanox Technologies MT43244 BlueField-3 integrated
+    ConnectX-7 network controller (rev 01)'
+- bus: '01'
+  dev: '00'
+  fn: '1'
+  id: c2d5
+  name: 'DMA controller: Mellanox Technologies MT43244 BlueField-3 SoC Management
+    Interface (rev 01)'
+- bus: '02'
+  dev: '00'
+  fn: '0'
+  id: a2dc
+  name: 'Ethernet controller: Mellanox Technologies MT43244 BlueField-3 integrated
+    ConnectX-7 network controller (rev 01)'
+- bus: '02'
+  dev: '00'
+  fn: '1'
+  id: c2d5
+  name: 'DMA controller: Mellanox Technologies MT43244 BlueField-3 SoC Management
+    Interface (rev 01)'
 - bus: '03'
   dev: '00'
   fn: '0'
   id: '5765'
-  name: 'Non-Volatile memory controller: Realtek Semiconductor Co., Ltd. RTS5765DL
-    NVMe SSD Controller (DRAM-less) (rev 01)'
+  name: 'Non-Volatile memory controller: Device 1f9f:5765 (rev 01)'
 - bus: '06'
   dev: '00'
   fn: '0'
   id: cf70
   name: 'Ethernet controller: Mellanox Technologies Spectrum-3'
+- bus: '07'
+  dev: '00'
+  fn: '0'
+  id: a2dc
+  name: 'Ethernet controller: Mellanox Technologies MT43244 BlueField-3 integrated
+    ConnectX-7 network controller (rev 01)'
+- bus: '07'
+  dev: '00'
+  fn: '1'
+  id: c2d5
+  name: 'DMA controller: Mellanox Technologies MT43244 BlueField-3 SoC Management
+    Interface (rev 01)'
+- bus: 08
+  dev: '00'
+  fn: '0'
+  id: a2dc
+  name: 'Ethernet controller: Mellanox Technologies MT43244 BlueField-3 integrated
+    ConnectX-7 network controller (rev 01)'
+- bus: 08
+  dev: '00'
+  fn: '1'
+  id: c2d5
+  name: 'DMA controller: Mellanox Technologies MT43244 BlueField-3 SoC Management
+    Interface (rev 01)'
 - bus: 09
   dev: '00'
   fn: '0'

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
@@ -313,7 +313,7 @@ class DpuCtlPlat():
             self.log_info(f"Failed to rescan")
         return False
 
-    def dpu_power_on(self, forced=False):
+    def dpu_power_on(self, forced=False, skip_pre_post=False):
         """Per DPU Power on API"""
         with self.boot_prog_context():
             self.log_info(f"Power on with force = {forced}")
@@ -327,13 +327,15 @@ class DpuCtlPlat():
                 return_value = self._power_on_force()
             else:
                 return_value = self._power_on()
-            self.dpu_post_startup()
+            if not skip_pre_post:
+                self.dpu_post_startup()
             return return_value
 
-    def dpu_power_off(self, forced=False):
+    def dpu_power_off(self, forced=False, skip_pre_post=False):
         """Per DPU Power off API"""
         with self.boot_prog_context():
-            self.dpu_pre_shutdown()
+            if not skip_pre_post:
+                self.dpu_pre_shutdown()
             self.log_info(f"Power off with force = {forced}")
             if self.read_boot_prog() == BootProgEnum.RST.value:
                 self.log_info(f"Skipping DPU power off as DPU is already powered off")

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
@@ -492,12 +492,10 @@ class DpuModule(ModuleBase):
         Returns:
             Returns the PCI bus information in BDF format like "[DDDD:]BB:SS:F"
         """
-        if not self.bus_info:
-            # Cache the data to prevent multiple platform.json parsing
-            self.bus_info = DeviceDataManager.get_dpu_interface(self.get_name().lower(), DpuInterfaceEnum.PCIE_INT.value)
-            # If we are unable to parse platform.json for midplane interface raise RunTimeError
-            if not self.bus_info:
-                raise RuntimeError(f"Unable to obtain bus info from platform.json for {self.get_name()}")
+        if self.bus_info:
+            return self.bus_info
+        # Cache the data to prevent multiple platform.json parsing
+        self.bus_info = self.dpuctl_obj.get_pci_dev_path()
         return self.bus_info
 
     def pci_detach(self):

--- a/platform/mellanox/mlnx-platform-api/tests/test_module.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_module.py
@@ -370,6 +370,24 @@ class TestModule:
             assert m1._is_midplane_up()
             assert m2._is_midplane_up()
             assert m3._is_midplane_up()
+            
+            # Test get_pci_bus_info function
+            with patch.object(m1.dpuctl_obj, "get_pci_dev_path") as mock_get_pci_dev_path:
+                mock_get_pci_dev_path.return_value = "0000:08:00.0"
+                # First call should get the bus info from dpuctl_obj
+                assert m1.get_pci_bus_info() == "0000:08:00.0"
+                mock_get_pci_dev_path.assert_called_once()
+                # Second call should use cached value
+                assert m1.get_pci_bus_info() == "0000:08:00.0"
+                # Should not call get_pci_dev_path again
+                mock_get_pci_dev_path.assert_called_once()
+                
+                # Test with a different module
+                with patch.object(m2.dpuctl_obj, "get_pci_dev_path") as mock_get_pci_dev_path2:
+                    mock_get_pci_dev_path2.return_value = "0000:09:00.0"
+                    assert m2.get_pci_bus_info() == "0000:09:00.0"
+                    mock_get_pci_dev_path2.assert_called_once()
+            
             assert m1.get_pci_bus_info() == pl_data["dpu0"]['bus_info']
             assert m2.get_pci_bus_info() == pl_data["dpu1"]['bus_info']
             assert m3.get_pci_bus_info() == pl_data["dpu2"]['bus_info']


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

