### PR TITLE
[Smartswitch][Pmon] Added changes relevant to pcie attach and detach and sensord 

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn4280-r0/module_sensors_ignore_conf/ignore_sensors_DPU0.conf
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/module_sensors_ignore_conf/ignore_sensors_DPU0.conf
@@ -1,0 +1,30 @@
+bus "i2c-18" "i2c-1-mux (chan_id 17)"
+    chip "mp2975-i2c-18-69"
+        ignore in1 
+        ignore in2 
+        ignore in3 
+        ignore temp1 
+        ignore power1 
+        ignore power2 
+        ignore power3 
+        ignore curr1 
+        ignore curr2 
+        ignore curr3 
+        ignore curr4
+        ignore curr5
+        ignore curr6
+
+    chip "mp2975-i2c-18-6A"
+        ignore in1 
+        ignore in2 
+        ignore temp1 
+        ignore power1 
+        ignore power2
+        ignore curr1 
+        ignore curr2 
+        ignore curr5
+
+    chip "tmp421-i2c-18-1F"
+        ignore temp1 
+        ignore temp2
+        ignore curr6

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/module_sensors_ignore_conf/ignore_sensors_DPU1.conf
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/module_sensors_ignore_conf/ignore_sensors_DPU1.conf
@@ -1,0 +1,30 @@
+bus "i2c-19" "i2c-1-mux (chan_id 18)"
+    chip "mp2975-i2c-19-69"
+        ignore in1 
+        ignore in2 
+        ignore in3 
+        ignore temp1 
+        ignore power1 
+        ignore power2 
+        ignore power3 
+        ignore curr1 
+        ignore curr2 
+        ignore curr3 
+        ignore curr4
+        ignore curr5
+        ignore curr6
+
+    chip "mp2975-i2c-19-6A"
+        ignore in1 
+        ignore in2 
+        ignore temp1 
+        ignore power1 
+        ignore power2
+        ignore curr1 
+        ignore curr2 
+        ignore curr5
+
+    chip "tmp421-i2c-19-1F"
+        ignore temp1 
+        ignore temp2
+        ignore curr6

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/module_sensors_ignore_conf/ignore_sensors_DPU2.conf
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/module_sensors_ignore_conf/ignore_sensors_DPU2.conf
@@ -1,0 +1,30 @@
+bus "i2c-20" "i2c-1-mux (chan_id 19)"
+    chip "mp2975-i2c-20-69"
+        ignore in1 
+        ignore in2 
+        ignore in3 
+        ignore temp1 
+        ignore power1 
+        ignore power2 
+        ignore power3 
+        ignore curr1 
+        ignore curr2 
+        ignore curr3 
+        ignore curr4
+        ignore curr5
+        ignore curr6
+
+    chip "mp2975-i2c-20-6A"
+        ignore in1 
+        ignore in2 
+        ignore temp1 
+        ignore power1 
+        ignore power2
+        ignore curr1 
+        ignore curr2 
+        ignore curr5
+
+    chip "tmp421-i2c-20-1F"
+        ignore temp1 
+        ignore temp2
+        ignore curr6

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/module_sensors_ignore_conf/ignore_sensors_DPU3.conf
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/module_sensors_ignore_conf/ignore_sensors_DPU3.conf
@@ -1,0 +1,30 @@
+bus "i2c-21" "i2c-1-mux (chan_id 20)"
+    chip "mp2975-i2c-21-69"
+        ignore in1 
+        ignore in2 
+        ignore in3 
+        ignore temp1 
+        ignore power1 
+        ignore power2 
+        ignore power3 
+        ignore curr1 
+        ignore curr2 
+        ignore curr3 
+        ignore curr4
+        ignore curr5
+        ignore curr6
+
+    chip "mp2975-i2c-21-6A"
+        ignore in1 
+        ignore in2 
+        ignore temp1 
+        ignore power1 
+        ignore power2
+        ignore curr1 
+        ignore curr2 
+        ignore curr5
+
+    chip "tmp421-i2c-21-1F"
+        ignore temp1 
+        ignore temp2
+        ignore curr6

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/pcie.yaml
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/pcie.yaml
@@ -230,17 +230,64 @@
   id: '1467'
   name: 'Host bridge: Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh)
     Data Fabric: Device 18h; Function 7'
+- bus: '01'
+  dev: '00'
+  fn: '0'
+  id: a2dc
+  name: 'Ethernet controller: Mellanox Technologies MT43244 BlueField-3 integrated
+    ConnectX-7 network controller (rev 01)'
+- bus: '01'
+  dev: '00'
+  fn: '1'
+  id: c2d5
+  name: 'DMA controller: Mellanox Technologies MT43244 BlueField-3 SoC Management
+    Interface (rev 01)'
+- bus: '02'
+  dev: '00'
+  fn: '0'
+  id: a2dc
+  name: 'Ethernet controller: Mellanox Technologies MT43244 BlueField-3 integrated
+    ConnectX-7 network controller (rev 01)'
+- bus: '02'
+  dev: '00'
+  fn: '1'
+  id: c2d5
+  name: 'DMA controller: Mellanox Technologies MT43244 BlueField-3 SoC Management
+    Interface (rev 01)'
 - bus: '03'
   dev: '00'
   fn: '0'
   id: '5765'
-  name: 'Non-Volatile memory controller: Realtek Semiconductor Co., Ltd. RTS5765DL
-    NVMe SSD Controller (DRAM-less) (rev 01)'
+  name: 'Non-Volatile memory controller: Device 1f9f:5765 (rev 01)'
 - bus: '06'
   dev: '00'
   fn: '0'
   id: cf70
   name: 'Ethernet controller: Mellanox Technologies Spectrum-3'
+- bus: '07'
+  dev: '00'
+  fn: '0'
+  id: a2dc
+  name: 'Ethernet controller: Mellanox Technologies MT43244 BlueField-3 integrated
+    ConnectX-7 network controller (rev 01)'
+- bus: '07'
+  dev: '00'
+  fn: '1'
+  id: c2d5
+  name: 'DMA controller: Mellanox Technologies MT43244 BlueField-3 SoC Management
+    Interface (rev 01)'
+- bus: 08
+  dev: '00'
+  fn: '0'
+  id: a2dc
+  name: 'Ethernet controller: Mellanox Technologies MT43244 BlueField-3 integrated
+    ConnectX-7 network controller (rev 01)'
+- bus: 08
+  dev: '00'
+  fn: '1'
+  id: c2d5
+  name: 'DMA controller: Mellanox Technologies MT43244 BlueField-3 SoC Management
+    Interface (rev 01)'
 - bus: 09
   dev: '00'
   fn: '0'

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/pcie.yaml
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/pcie.yaml
@@ -1,7 +1,7 @@
 ##
 ## SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-## Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-## Apache-2.0
+## Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+## SPDX-License-Identifier: Apache-2.0
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
@@ -258,8 +258,8 @@ class DpuCtlPlat():
                 if os.path.exists(remove_path):
                     self.write_file(remove_path, OperationType.SET.value)
             return True
-        except Exception:
-            self.log_info(f"Failed PCI Removal!")
+        except Exception as e:
+            self.log_error(f"Failed PCI Removal with error {e}")
         return False
 
     def dpu_pci_scan(self):
@@ -268,11 +268,11 @@ class DpuCtlPlat():
             pci_scan_path = "/sys/bus/pci/rescan"
             self.write_file(pci_scan_path, OperationType.SET.value)
             return True
-        except Exception:
-            self.log_info(f"Failed to rescan")
+        except Exception as e:
+            self.log_error(f"Failed to rescan with error {e}")
         return False
 
-    def dpu_power_on(self, forced=False):
+    def dpu_power_on(self, forced=False, skip_pre_post=False):
         """Per DPU Power on API"""
         with self.boot_prog_context():
             self.log_info(f"Power on with force = {forced}")
@@ -286,13 +286,15 @@ class DpuCtlPlat():
                 return_value = self._power_on_force()
             else:
                 return_value = self._power_on()
-            self.dpu_post_startup()
+            if not skip_pre_post:
+                self.dpu_post_startup()
             return return_value
 
-    def dpu_power_off(self, forced=False):
+    def dpu_power_off(self, forced=False, skip_pre_post=False):
         """Per DPU Power off API"""
         with self.boot_prog_context():
-            self.dpu_pre_shutdown()
+            if not skip_pre_post:
+                self.dpu_pre_shutdown()
             self.log_info(f"Power off with force = {forced}")
             if self.read_boot_prog() == BootProgEnum.RST.value:
                 self.log_info(f"Skipping DPU power off as DPU is already powered off")


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

