### PR TITLE
[nvidia-bluefield] Fix bluefield build during create image stage 

### DIFF
--- a/platform/nvidia-bluefield/installer/create_sonic_image
+++ b/platform/nvidia-bluefield/installer/create_sonic_image
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -203,11 +203,11 @@ copy_bin()
     if [ -e $1 ]; then
         bin=$1
     else
-        bin=$(which $1 2> /dev/null)
+        bin=$(which $1 2> /dev/null || true)
     fi
     if [ -z "$bin" ]; then
         echo "ERROR: Cannot find $1"
-        exit 1
+        return 0
     fi
     sudo mkdir -p .$(dirname $bin)
     if [ ! -e .${bin} ]; then


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The create image stage in nvidia-bluefield build is failing in the pipeline due to updates in the grub2-common package which is not handled correctly

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
copy_bin related failures are suppressed because some of the fiels are removed before the create_sonic_image function is called
#### How to verify it
Before fix:
```
2025-07-27T13:26:00.0543363Z + '[' bfb = onie ']'
2025-07-27T13:26:00.0543540Z + '[' bfb = raw ']'
2025-07-27T13:26:00.0543734Z + '[' bfb = kvm ']'
2025-07-27T13:26:00.0543910Z + '[' bfb = aboot ']'
2025-07-27T13:26:00.0544088Z + '[' bfb = dsc ']'
2025-07-27T13:26:00.0544266Z + '[' bfb = bfb ']'
2025-07-27T13:26:00.0544448Z + echo 'Build BFB installer'
2025-07-27T13:26:00.0544636Z Build BFB installer
2025-07-27T13:26:00.0544820Z + [[ no_sign != \n\o\_\s\i\g\n ]]
2025-07-27T13:26:00.0545067Z + sudo -E ./platform/nvidia-bluefield/installer/create_sonic_image --kernel 6.1.0-29-2-arm64 ''
2025-07-27T13:26:00.0545320Z --kernel 6.1.0-29-2-arm64
2025-07-27T13:26:00.0545519Z Work directory: /sonic/bfb-wd-QBs3
2025-07-27T13:26:00.0545716Z /sonic/bfb-wd-QBs3 /sonic
2025-07-27T13:26:00.0545926Z Rebuilding /sonic/bfb-wd-QBs3/dump-initramfs-v0
2025-07-27T13:26:00.0546158Z /sonic/bfb-wd-QBs3/initramfs /sonic/bfb-wd-QBs3 /sonic
2025-07-27T13:26:00.0546358Z 251017 blocks
2025-07-27T13:26:00.0546562Z [  FAIL LOG END  ] [ target/sonic-nvidia-bluefield.bfb ]
2025-07-27T13:26:00.0546812Z make: *** [slave.mk:1428: target/sonic-nvidia-bluefield.bfb] Error 1
2025-07-27T13:26:15.5130458Z make[1]: *** [Makefile.work:616: target/sonic-nvidia-bluefield.bfb] Error 2
2025-07-27T13:26:15.5130831Z make[1]: Leaving directory '/data/work/1/s'
2025-07-27T13:26:15.5311244Z make: *** [Makefile:55: target/sonic-nvidia-bluefield.bfb] Error 2
2025-07-27T13:26:15.5450843Z 
2025-07-27T13:26:15.5772936Z ##[error]Bash exited with code '2'.
2025-07-27T13:26:15.6006264Z ##[section]Finishing: Build sonic image
```
After fix the compilation passes

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

