### PR TITLE
[Mellanox][Smartswitch] Changed reset cause for DPUs to align with switch

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
@@ -278,7 +278,7 @@ class DpuModule(ModuleBase):
             f'{self.reboot_base_path}reset_dpu_thermal':
                 (ChassisBase.REBOOT_CAUSE_THERMAL_OVERLOAD_OTHER, 'Thermal shutdown of the DPU'),
             f'{self.reboot_base_path}reset_pwr_off':
-                ("Reboot", 'Reset due to Power off'),
+                (ChassisBase.REBOOT_CAUSE_NON_HARDWARE, 'Reset due to Power off'),
         }
         self.chassis_state_db = SonicV2Connector(host="127.0.0.1")
         self.chassis_state_db.connect(self.chassis_state_db.CHASSIS_STATE_DB)

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
@@ -274,11 +274,11 @@ class DpuModule(ModuleBase):
             f'{self.reboot_base_path}reset_comex_pwr_fail':
                 (ChassisBase.REBOOT_CAUSE_POWER_LOSS, 'Power failed to comex module'),
             f'{self.reboot_base_path}reset_from_main_board':
-                (ChassisBase.REBOOT_CAUSE_NON_HARDWARE, 'Reset from Main board'),
+                ("Reboot", 'Reset from Main board'),
             f'{self.reboot_base_path}reset_dpu_thermal':
                 (ChassisBase.REBOOT_CAUSE_THERMAL_OVERLOAD_OTHER, 'Thermal shutdown of the DPU'),
             f'{self.reboot_base_path}reset_pwr_off':
-                (ChassisBase.REBOOT_CAUSE_NON_HARDWARE, 'Reset due to Power off'),
+                ("Reboot", 'Reset due to Power off'),
         }
         self.chassis_state_db = SonicV2Connector(host="127.0.0.1")
         self.chassis_state_db.connect(self.chassis_state_db.CHASSIS_STATE_DB)

--- a/platform/mellanox/mlnx-platform-api/tests/test_module.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_module.py
@@ -322,7 +322,7 @@ class TestModule:
             (ChassisBase.REBOOT_CAUSE_POWER_LOSS, 'Power failed to comex module'),
             ("Reboot", 'Reset from Main board'),
             (ChassisBase.REBOOT_CAUSE_THERMAL_OVERLOAD_OTHER, 'Thermal shutdown of the DPU'),
-            ("Reboot", 'Reset due to Power off'),
+            (ChassisBase.REBOOT_CAUSE_NON_HARDWARE, 'Reset due to Power off'),
             (ChassisBase.REBOOT_CAUSE_NON_HARDWARE, ''),
         ]
         with patch("sonic_platform.utils.read_int_from_file", wraps=mock_read_int_from_file):

--- a/platform/mellanox/mlnx-platform-api/tests/test_module.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_module.py
@@ -320,9 +320,9 @@ class TestModule:
         reboot_cause_list = [
             (ChassisBase.REBOOT_CAUSE_POWER_LOSS, 'power auxiliary outage or reload'),
             (ChassisBase.REBOOT_CAUSE_POWER_LOSS, 'Power failed to comex module'),
-            (ChassisBase.REBOOT_CAUSE_NON_HARDWARE, 'Reset from Main board'),
+            ("Reboot", 'Reset from Main board'),
             (ChassisBase.REBOOT_CAUSE_THERMAL_OVERLOAD_OTHER, 'Thermal shutdown of the DPU'),
-            (ChassisBase.REBOOT_CAUSE_NON_HARDWARE, 'Reset due to Power off'),
+            ("Reboot", 'Reset due to Power off'),
             (ChassisBase.REBOOT_CAUSE_NON_HARDWARE, ''),
         ]
         with patch("sonic_platform.utils.read_int_from_file", wraps=mock_read_int_from_file):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In mellanox switches, the reboot cause on reboot of switch is just reboot, In case of DPU, until now we had `Non-hardware` in order to align the reboot cause of DPU and switch, the reboot cause of DPU is updated/

On execution of the command `reboot` or `reboot -d DPUx` the reboot cause of DPU has to be updated to provide the reboot cause as `Reboot`

This change only affects DPUs and no other systems

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
The `module.py` file which contains the `DpuModule` object which represents the DPU is changed. The relevant sysfs file which is set when we perform reboot of the DPU, is updated to indicate that the reboot cause should be `"Reboot"`
Corresponding unit test is also updated in `test_module.py`

#### How to verify it

Unit test to confirm that the build is successful
`tests/test_module.py::TestModule::test_dpu_module PASSED                 [ 52%]`

Checked reboot cause on device
```
root@sonic:/home/admin# show reboot-cause all
Device    Name                 Cause         Time                             User
--------  -------------------  ------------  -------------------------------  ------
NPU       2025_09_02_18_29_55  reboot        Tue Sep  2 06:26:22 PM IDT 2025  admin
DPU3      2025_09_02_15_31_10  Reboot  Tue Sep 02 03:31:10 PM UTC 2025
DPU2      2025_09_02_15_31_10  Reboot  Tue Sep 02 03:31:10 PM UTC 2025
DPU1      2025_09_02_15_31_10  Reboot  Tue Sep 02 03:31:10 PM UTC 2025
DPU0      2025_09_02_15_31_10  Reboot  Tue Sep 02 03:31:10 PM UTC 2025
```


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

