### PR TITLE
[Mellanox][Smartswitch] Combination of reboot and verbosity addition into single PR

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
@@ -107,7 +107,7 @@ class DpuCtlPlat():
         self.pci_dev_path = []
         self.verbosity = False
 
-    def setup_logger(self, use_print=False):
+    def setup_logger(self, use_print=False, use_notice_level=False):
         def print_with_time(msg):
             timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
             print(f"[{timestamp}] {msg}")
@@ -117,8 +117,12 @@ class DpuCtlPlat():
             self.logger_error = print_with_time 
             self.logger_debug = print_with_time
             return
-        self.logger_debug = logger.log_debug
-        self.logger_info = logger.log_info
+        if use_notice_level:
+            self.logger_debug = logger.log_notice
+            self.logger_info = logger.log_notice
+        else:
+            self.logger_debug = logger.log_debug
+            self.logger_info = logger.log_info
         self.logger_error = logger.log_error
 
     def log_debug(self, msg=None):
@@ -408,7 +412,7 @@ class DpuCtlPlat():
         read_value = self.read_boot_prog()
         if read_value != self.boot_prog_state:
             self.dpu_boot_prog_update(read_value)
-            self.log_error(f"The boot_progress status is changed to = {self.boot_prog_indication}")
+            self.log_info(f"The boot_progress status is changed to = {self.boot_prog_indication}")
 
     def watch_boot_prog(self):
         """Read boot_progress and update the value in an infinite loop"""

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
@@ -334,13 +334,8 @@ class DpuModule(ModuleBase):
         Returns:
             bool: True if the request has been issued successfully, False if not
         """
-        # Skip pre shutdown and Post startup, handled by pci_detach and pci_reattach
-        if reboot_type == ModuleBase.MODULE_REBOOT_DPU:
-            return self.dpuctl_obj.dpu_reboot(skip_pre_post=True)
-        elif reboot_type == ModuleBase.MODULE_REBOOT_SMARTSWITCH:
-            # Do not wait for result if we are rebooting NPU + DPUs
-            return self.dpuctl_obj.dpu_reboot(no_wait=True, skip_pre_post=True)
-        raise RuntimeError(f"Invalid Reboot Type provided for {self._name}: {reboot_type}")
+        # no_wait=True is not supported at this point, because of race conditions with other drivers
+        return self.dpuctl_obj.dpu_reboot(skip_pre_post=True)
 
     def set_admin_state(self, up):
         """

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
@@ -262,6 +262,8 @@ class DpuModule(ModuleBase):
         self.dpu_id = dpu_id
         self._name = f"DPU{self.dpu_id}"
         self.dpuctl_obj = DpuCtlPlat(self._name.lower())
+        self.dpuctl_obj.setup_logger(use_notice_level=True)
+        self.dpuctl_obj.verbosity = True
         self.fault_state = False
         self.dpu_vpd_parser = DpuVpdParser('/var/run/hw-management/eeprom/vpd_data', self.dpuctl_obj._name.upper())
         self.CONFIG_DB_NAME = "CONFIG_DB"
@@ -335,7 +337,11 @@ class DpuModule(ModuleBase):
             bool: True if the request has been issued successfully, False if not
         """
         # no_wait=True is not supported at this point, because of race conditions with other drivers
-        return self.dpuctl_obj.dpu_reboot(skip_pre_post=True)
+        # Skip pre shutdown and Post startup, handled by pci_detach and pci_reattach
+        logger.log_notice(f"Rebooting {self._name} with type {reboot_type}")
+        return_value = self.dpuctl_obj.dpu_reboot(skip_pre_post=True)
+        logger.log_notice(f"Rebooted {self._name} with type {reboot_type} and return value {return_value}")
+        return return_value
 
     def set_admin_state(self, up):
         """
@@ -352,12 +358,16 @@ class DpuModule(ModuleBase):
         Returns:
             bool: True if the request has been issued successfully, False if not
         """
+        logger.log_notice(f"Setting the admin state for {self._name} to {up}")
         if up:
             if self.dpuctl_obj.dpu_power_on(skip_pre_post=True):
+                logger.log_notice(f"Completed the admin state change for {self._name} to {up}")
                 return True
             logger.log_error(f"Failed to set the admin state for {self._name}")
             return False
-        return self.dpuctl_obj.dpu_power_off(skip_pre_post=True)
+        return_value = self.dpuctl_obj.dpu_power_off(skip_pre_post=True)
+        logger.log_notice(f"Completed the admin state change for {self._name} to {up}")
+        return return_value
 
     def get_type(self):
         """

--- a/platform/mellanox/mlnx-platform-api/tests/test_module.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_module.py
@@ -253,9 +253,7 @@ class TestModule:
             mock_obj.assert_called_once_with(skip_pre_post=True)
             mock_obj.reset_mock()
             m.reboot(reboot_type=ModuleBase.MODULE_REBOOT_SMARTSWITCH)
-            mock_obj.assert_called_once_with(no_wait=True, skip_pre_post=True)
-            with pytest.raises(RuntimeError):
-                m.reboot("None")
+            mock_obj.assert_called_once_with(skip_pre_post=True)
         with patch('sonic_py_common.syslogger.SysLogger.log_error') as mock_method:
             m.dpuctl_obj.dpu_power_on = mock.MagicMock(return_value=True)
             assert m.set_admin_state(True)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This is a combination of #47 and #48 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

