### PR TITLE
Support for Standalone DPU platforms 

### DIFF
--- a/dockers/docker-database/docker-database-init.sh
+++ b/dockers/docker-database/docker-database-init.sh
@@ -30,15 +30,20 @@ fi
 
 if [[ $IS_DPU_DEVICE == "true" ]]
 then
-    midplane_ip=$( ip -4 -o addr show eth0-midplane | awk '{print $4}' | cut -d'/' -f1  )
-    if [[ $midplane_ip != "" ]]
-    then
+    if [[ $IS_APPLIANCE_DPU == "false" ]]; then
+        midplane_ip=$( ip -4 -o addr show eth0-midplane | awk '{print $4}' | cut -d'/' -f1  )
+        if [[ $midplane_ip != "" ]]
+        then
+            export DATABASE_TYPE="dpudb"
+            export REMOTE_DB_IP="169.254.200.254"
+            # Determine the DB PORT from midplane IP
+            IFS=. read -r a b c d <<< $midplane_ip
+            export REMOTE_DB_PORT=$((6380 + $d))
+        fi
+    else
         export DATABASE_TYPE="dpudb"
-        export REMOTE_DB_IP="169.254.200.254"
-        # Determine the DB PORT from midplane IP
-        IFS=. read -r a b c d <<< $midplane_ip
-        export REMOTE_DB_PORT=$((6380 + $d))
     fi
+
 fi
 
 export BMP_DB_PORT=6400

--- a/dockers/docker-database/docker-database-init.sh
+++ b/dockers/docker-database/docker-database-init.sh
@@ -30,7 +30,7 @@ fi
 
 if [[ $IS_DPU_DEVICE == "true" ]]
 then
-    if [[ $IS_APPLIANCE_DPU == "false" ]]; then
+    if [[ $IS_APPLIANCE_DPU != "true" ]]; then
         midplane_ip=$( ip -4 -o addr show eth0-midplane | awk '{print $4}' | cut -d'/' -f1  )
         if [[ $midplane_ip != "" ]]
         then

--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -98,7 +98,7 @@ fi
 
 # Enable ZMQ
 LOCALHOST_SUBTYPE=`sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "subtype"`
-if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" ]]; then
+if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" || x"${LOCALHOST_SUBTYPE}" == x"Appliance" ]]; then
     midplane_mgmt_state=$( ip -json -4 addr show eth0-midplane | jq -r ".[0].operstate" )
     mgmt_ip=$( ip -json -4 addr show eth0 | jq -r ".[0].addr_info[0].local" )
     if [[ $midplane_mgmt_state == "UP" ]]; then

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -87,7 +87,7 @@ fi
 
 # Enable ZMQ for SmartSwitch
 LOCALHOST_SUBTYPE=`sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "subtype"`
-if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" ]]; then
+if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" || x"${LOCALHOST_SUBTYPE}" == x"Appliance" ]]; then
     TELEMETRY_ARGS+=" -zmq_port=8100"
 fi
 

--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -297,13 +297,48 @@ def generate_l2_config(data):
             data['VLAN_MEMBER']['Vlan1000|{}'.format(port)] = {'tagging_mode': 'untagged'}
     return data
 
+def generate_appliance_config(data):
+    data['DEVICE_METADATA']['localhost']['hostname'] = 'sonic'
+    data['DEVICE_METADATA']['localhost']['switch_type'] = 'dpu'
+    data['DEVICE_METADATA']['localhost']['type'] = 'SonicHost'
+    data['DEVICE_METADATA']['localhost']['subtype'] = 'Appliance'
+    data['DEVICE_METADATA']['localhost']['bgp_asn'] = '65100'
+    data['LOOPBACK_INTERFACE'] = {"Loopback0": {},
+                                  "Loopback0|10.1.0.1/32": {}}
+    data['BGP_NEIGHBOR'] = {}
+    data['DEVICE_NEIGHBOR'] = {}
+    data['INTERFACE'] = {}
+    port_number = 0
+    total_port_amount = len(data['PORT'])
+    for port in natsorted(data['PORT']):
+        data['PORT'][port]['admin_status'] = 'up'
+        data['PORT'][port]['mtu'] = '9100'
+        local_addr = '10.0.{}.{}'.format(2 * port_number // 256, 2 * port_number % 256)
+        peer_addr = '10.0.{}.{}'.format(2 * port_number // 256, 2 * port_number % 256 + 1)
+        peer_name='ARISTA{0:02d}T1'.format(1 + port_number % (total_port_amount // 2 or 1))
+        peer_asn = 64001 + port_number
+        data['INTERFACE']['{}'.format(port)] = {}
+        data['INTERFACE']['{}|{}/31'.format(port, local_addr)] = {}
+        data['BGP_NEIGHBOR'][peer_addr] = {
+                'rrclient': 0,
+                'name': peer_name,
+                'local_addr': local_addr,
+                'nhopself': 0,
+                'holdtime': '180',
+                'asn': str(peer_asn),
+                'keepalive': '60'
+                }
+        port_number += 1
+    return data
+
 _sample_generators = {
         't1': generate_t1_sample_config,
         'l2': generate_l2_config,
         't1-smartswitch': generate_t1_smartswitch_sample_config,
         'empty': generate_empty_config,
         'l1': generate_l1_config,
-        'l3': generate_l3_config
+        'l3': generate_l3_config,
+        'appliance': generate_appliance_config
         }
 
 def get_available_config():

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -169,7 +169,7 @@ module sonic-device_metadata {
 
                 leaf subtype {
                     type string {
-                        pattern "DualToR|SmartSwitch|Supervisor|UpstreamLC|DownstreamLC|LowerSpineRouter";
+                        pattern "DualToR|SmartSwitch|Supervisor|UpstreamLC|DownstreamLC|LowerSpineRouter|Appliance";
                     }
                 }
 

--- a/src/systemd-sonic-generator/ssg-test.cc
+++ b/src/systemd-sonic-generator/ssg-test.cc
@@ -201,6 +201,7 @@ struct SsgMainConfig {
     int num_asics = 0;
     bool is_smart_switch_npu = false;
     bool is_smart_switch_dpu = false;
+    bool is_appliance_dpu = false;
     int num_dpus = 0;
 };
 
@@ -367,7 +368,7 @@ class SsgMainTest : public SsgFunctionTest {
 
     void validate_environment_variable(const SsgMainConfig &cfg) {
         std::unordered_map<std::string, std::string> env_vars;
-        env_vars["IS_DPU_DEVICE"] = (cfg.is_smart_switch_dpu ? "true" : "false");
+        env_vars["IS_DPU_DEVICE"] = (cfg.is_smart_switch_dpu || cfg.is_appliance_dpu ? "true" : "false");
         env_vars["NUM_DPU"] = std::to_string(cfg.num_dpus);
 
         std::vector<std::string> checked_service_list;

--- a/src/systemd-sonic-generator/systemd-sonic-generator.cpp
+++ b/src/systemd-sonic-generator/systemd-sonic-generator.cpp
@@ -81,6 +81,7 @@ static char** multi_instance_services;
 static int num_multi_inst;
 static bool smart_switch_npu;
 static bool smart_switch_dpu;
+static bool appliance_dpu;
 static bool smart_switch;
 static int num_dpus;
 static char* platform = NULL;
@@ -409,7 +410,8 @@ static void update_environment(const std::string &src)
     }
 
     std::unordered_map<std::string, std::string> env_vars;
-    env_vars["IS_DPU_DEVICE"] = (smart_switch_dpu ? "true" : "false");
+    env_vars["IS_DPU_DEVICE"] = (smart_switch_dpu || appliance_dpu ? "true" : "false");
+    env_vars["IS_APPLIANCE_DPU"] = (appliance_dpu ? "true" : "false");
     env_vars["NUM_DPU"] = std::to_string(num_dpus);
 
     for (const auto& [key, value] : env_vars) {
@@ -915,6 +917,15 @@ static bool is_smart_switch_dpu() {
     return json_object_object_get_ex(platform_info, "DPU", &dpu);
 }
 
+static bool is_appliance_dpu() {
+    struct json_object *dpu;
+    const struct json_object *platform_info = get_platform_info();
+    if (platform_info == NULL) {
+        return false;
+    }
+    return json_object_object_get_ex(platform_info, "APPLIANCE_DPU", &dpu);
+}
+
 
 /**
  * @brief Retrieves the number of DPUs (Data Processing Units).
@@ -1164,6 +1175,7 @@ int ssg_main(int argc, char **argv) {
     num_asics = get_num_of_asic();
     smart_switch_npu = is_smart_switch_npu();
     smart_switch_dpu = is_smart_switch_dpu();
+    appliance_dpu = is_appliance_dpu();
     smart_switch = smart_switch_npu || smart_switch_dpu;
     num_dpus = get_num_of_dpu();
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Support for new DPU platform and for the Standalone DPU "Appliance" Topology
Changes introduced:
Platform independent changes:
- `dockers/docker-database/docker-database-init.sh` Support for Appliance DPU, do not export `REMOTE_DB_PORT` and  `REMOTE_DB_IP` in case of appliance DPU, so that database is initialized with local `DPU_APPL_DB` and `DPU_STATE_DB` in case of appliance topology
- `dockers/docker-orchagent/orchagent.sh`  - Allow zmq initialization in orchagent for Appliance subtype
- `dockers/docker-sonic-gnmi/gnmi-native.sh` - Allow zmq port initialization in the gnmi server for Appliance subtype
- `src/sonic-config-engine/config_samples.py` - Add support for appliance topology and generate basic default config during first boot
- `src/sonic-yang-models/yang-models/sonic-device_metadata.yang` - Yang validation update for appliance topology
- `src/systemd-sonic-generator/systemd-sonic-generator.cpp` - Differentiate between APPLIANCE_DPU and SMARTSWITCH_DPU during systemd service generation, this is done by checking for `APPLIANCE_DPU` key in platform.json


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Updated changes as described above

#### How to verify it
Test with manual deployment of image generated after build on standalone DPU device to test the SONiC image

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

