### PR TITLE
[Smartswitch] Added additional logging to improve pci scan time record

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
@@ -40,7 +40,7 @@ SYSTEM_BASE = os.path.join(HW_BASE, "system/")
 PCI_BASE = "/sys/bus/pci/"
 PCI_DEV_BASE = os.path.join(PCI_BASE, "devices/")
 
-logger = SysLogger()
+logger = SysLogger("dpuctl_plat")
 
 WAIT_FOR_SHTDN = 120
 WAIT_FOR_DPU_READY = 180
@@ -112,6 +112,7 @@ class DpuCtlPlat():
         def print_with_time(msg):
             timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
             print(f"[{timestamp}] {msg}")
+            self.logger.log_notice(f"{self.dpu_name}: {msg}")
 
         if use_print:
             self.logger_info = print_with_time
@@ -270,7 +271,8 @@ class DpuCtlPlat():
             for pci_dev_path in self.get_pci_dev_path():
                 remove_path = os.path.join(pci_dev_path, "remove")
                 if os.path.exists(remove_path):
-                    self.write_file(remove_path, OperationType.SET.value)
+                    with self.time_check_context("pci remove {pci_dev_path}"):
+                        self.write_file(remove_path, OperationType.SET.value)
             return True
         except Exception as e:
             self.log_error(f"Failed PCI Removal with error {e}")
@@ -280,7 +282,8 @@ class DpuCtlPlat():
         """PCI Scan API"""
         try:
             pci_scan_path = "/sys/bus/pci/rescan"
-            self.write_file(pci_scan_path, OperationType.SET.value)
+            with self.time_check_context("pci scan"):
+                self.write_file(pci_scan_path, OperationType.SET.value)
             return True
         except Exception as e:
             self.log_error(f"Failed to rescan with error {e}")

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
@@ -112,7 +112,7 @@ class DpuCtlPlat():
         def print_with_time(msg):
             timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
             print(f"[{timestamp}] {msg}")
-            self.logger.log_notice(f"{self.dpu_name}: {msg}")
+            logger.log_notice(f"{self.dpu_name}: {msg}")
 
         if use_print:
             self.logger_info = print_with_time

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
@@ -1,7 +1,7 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# Apache-2.0
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
@@ -271,7 +271,7 @@ class DpuCtlPlat():
             for pci_dev_path in self.get_pci_dev_path():
                 remove_path = os.path.join(pci_dev_path, "remove")
                 if os.path.exists(remove_path):
-                    with self.time_check_context("pci remove {pci_dev_path}"):
+                    with self.time_check_context(f"pci remove {pci_dev_path}"):
                         self.write_file(remove_path, OperationType.SET.value)
             return True
         except Exception as e:

--- a/platform/mellanox/mlnx-platform-api/tests/test_dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_dpuctlplat.py
@@ -67,7 +67,7 @@ class TestDpuCtlPlatInit:
         # Test with print mode
         dpuctl_obj.setup_logger(True)
         # Test that the logger functions add timestamps. Patch logger so it doesn't
-        # run in test (avoids socket errors and extra print calls from tracebacks).
+        # run in test (avoids socket errors and extra print calls from errors).
         with patch('time.strftime') as mock_time:
             mock_time.return_value = "2024-01-01 12:00:00"
             with patch('builtins.print') as mock_print, \

--- a/platform/mellanox/mlnx-platform-api/tests/test_dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_dpuctlplat.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,10 +66,12 @@ class TestDpuCtlPlatInit:
         """Test logger setup"""
         # Test with print mode
         dpuctl_obj.setup_logger(True)
-        # Test that the logger functions add timestamps
+        # Test that the logger functions add timestamps. Patch syslogger so it doesn't
+        # run in test env (avoids socket errors and extra print calls from tracebacks).
         with patch('time.strftime') as mock_time:
             mock_time.return_value = "2024-01-01 12:00:00"
-            with patch('builtins.print') as mock_print:
+            with patch('builtins.print') as mock_print, \
+                 patch('sonic_platform.dpuctlplat.logger.log_notice'):
                 dpuctl_obj.logger_info("test message")
                 mock_print.assert_called_once_with("[2024-01-01 12:00:00] test message")
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_dpuctlplat.py
@@ -66,8 +66,8 @@ class TestDpuCtlPlatInit:
         """Test logger setup"""
         # Test with print mode
         dpuctl_obj.setup_logger(True)
-        # Test that the logger functions add timestamps. Patch syslogger so it doesn't
-        # run in test env (avoids socket errors and extra print calls from tracebacks).
+        # Test that the logger functions add timestamps. Patch logger so it doesn't
+        # run in test (avoids socket errors and extra print calls from tracebacks).
         with patch('time.strftime') as mock_time:
             mock_time.return_value = "2024-01-01 12:00:00"
             with patch('builtins.print') as mock_print, \

--- a/platform/mellanox/sonic-bfb-installer.sh
+++ b/platform/mellanox/sonic-bfb-installer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -226,7 +226,20 @@ run_dpuctl_reset() {
     if [[ "$use_verbose" == true ]]; then
         reset_cmd="$reset_cmd -v"
     fi
-    eval $reset_cmd
+    local start_time
+    start_time=$(date +%s)
+    eval $reset_cmd &
+    local pid=$!
+    while kill -0 $pid 2>/dev/null; do
+        local elapsed=$(($(date +%s) - start_time))
+        printf "\r%s: Reboot: %d seconds elapsed" "$dpu" "$elapsed"
+        sleep 5
+    done
+    wait $pid
+    local end_time
+    end_time=$(date +%s)
+    local elapsed=$((end_time - start_time))
+    printf "\r%s: Reboot: %d seconds elapsed in total\n" "$dpu" "$elapsed"
 }
 
 # Function to reset DPU using reboot helper or fallback to dpuctl


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add additional logging to infer the time taken for DPU to rescan and scan
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add additional logging

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

