### PR TITLE
[master_RC] Removed use of mst driver in mellanox platform

### DIFF
--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -84,7 +84,6 @@ function PrintHelp() {
     echo "  -c, --clear-semaphore   Clear hw resources before updating firmware"
 {% if sonic_asic_platform == "nvidia-bluefield" %}
     echo "  -r, --reset    Reset firmware configuration (NVIDIA BlueField platform only)"
-    echo "  -n, --no-mst  Do not start MST drivers (NVIDIA BlueField platform only)"
 {% endif %}
     echo "  -h, --help     Print help"
     echo
@@ -118,9 +117,6 @@ function ParseArguments() {
             ;;
             -c|--clear-semaphore)
                 CLEAR_SEMAPHORE="${YES_PARAM}"
-            ;;
-            -n|--no-mst)
-                NO_MST="${YES_PARAM}"
             ;;
 {% if sonic_asic_platform == "nvidia-bluefield" %}
             -r|--reset)
@@ -236,12 +232,6 @@ function WaitForDevice() {
     local -r DEVICE_TYPE=$(GetMstDeviceType)
     local SPC_MST_DEV
     local QUERY_RC=""
-
-    if [[ "${NO_MST}" != "${YES_PARAM}" ]]; then
-        LogInfo "Restarting MST device"
-        /usr/bin/mst restart --with_i2cdev
-    fi
-
     while : ; do
         SPC_MST_DEV=$(GetSPCMstDevice)
         ${QUERY_XML} -d ${SPC_MST_DEV} -o ${QUERY_FILE}

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -33,6 +33,7 @@ try:
     from sonic_py_common import device_info
     from sonic_py_common.logger import Logger
     from sonic_py_common.general import check_output_pipe
+    import contextlib
     if sys.version_info[0] > 2:
         import configparser
     else:
@@ -762,19 +763,12 @@ class ComponentCPLD(Component):
         self.image_ext_name = self.COMPONENT_FIRMWARE_EXTENSION
 
     def __get_mst_device(self):
-        if not os.path.exists(self.MST_DEVICE_PATH):
-            print("ERROR: mst driver is not loaded")
-            return None
-
-        pattern = os.path.join(self.MST_DEVICE_PATH, self.MST_DEVICE_PATTERN)
-
-        mst_dev_list = glob.glob(pattern)
-        if not mst_dev_list or len(mst_dev_list) != 1:
-            devices = str(os.listdir(self.MST_DEVICE_PATH))
-            print("ERROR: Failed to get mst device: pattern={}, devices={}".format(pattern, devices))
-            return None
-
-        return mst_dev_list[0]
+        output = None
+        try:
+            output = subprocess.check_output(['/usr/bin/asic_detect/asic_detect.sh', '-p']).decode('utf-8').strip()
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError("Failed to get {} mst device: {}".format(self.name, str(e)))
+        return output
 
     def _install_firmware(self, image_path):
         if not self._check_file_validity(image_path):
@@ -940,14 +934,28 @@ class ComponenetFPGADPU(ComponentCPLD):
 
     CPLD_FIRMWARE_UPDATE_COMMAND = ['cpldupdate', '--cpld_chain', '2', '--gpio', '--print-progress', '']
 
+    @contextlib.contextmanager
+    def _mst_context(self):
+        try:
+            subprocess.check_call(['/usr/bin/mst', 'start'], universal_newlines=True)
+            yield
+        except subprocess.CalledProcessError as e:
+            logger.log_error("Failed to manage {} mst: {}".format(self.name, str(e)))
+            raise
+        finally:
+            try:
+                subprocess.check_call(['/usr/bin/mst', 'stop'], universal_newlines=True)
+            except subprocess.CalledProcessError as e:
+                logger.log_error("Failed to stop {} mst: {}".format(self.name, str(e)))
+
     def _install_firmware(self, image_path):
         self.CPLD_FIRMWARE_UPDATE_COMMAND[5] = image_path
 
         try:
             print("INFO: Installing {} firmware update: path={}".format(self.name, image_path))
-            subprocess.check_call(self.CPLD_FIRMWARE_UPDATE_COMMAND, universal_newlines=True)
+            with self._mst_context():
+                subprocess.check_call(self.CPLD_FIRMWARE_UPDATE_COMMAND, universal_newlines=True)
         except subprocess.CalledProcessError as e:
             print("ERROR: Failed to update {} firmware: {}".format(self.name, str(e)))
             return False
-
         return True

--- a/platform/mellanox/mlnx-platform-api/tests/test_component.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_component.py
@@ -293,15 +293,18 @@ class TestComponent:
         for index, item in enumerate(component_list):
             assert item.name == 'DPU{}_FPGA'.format(index + 1)
 
-    def test_cpld_get_mst_device(self):
+    @mock.patch('sonic_platform.component.subprocess.check_output')
+    def test_cpld_get_mst_device(self, mock_check_output):
         ComponentCPLD.MST_DEVICE_PATH = '/tmp/mst'
         os.system('rm -rf /tmp/mst')
         c = ComponentCPLD(1)
-        assert c._ComponentCPLD__get_mst_device() is None
+        mock_check_output.return_value = b''
+        assert c._ComponentCPLD__get_mst_device() == ''
         os.makedirs(ComponentCPLD.MST_DEVICE_PATH)
-        assert c._ComponentCPLD__get_mst_device() is None
+        assert c._ComponentCPLD__get_mst_device() == ''
         with open('/tmp/mst/mt0_pci_cr0', 'w+') as f:
             f.write('dummy')
+        mock_check_output.return_value = b'/tmp/mst/mt0_pci_cr0'
         assert c._ComponentCPLD__get_mst_device() == '/tmp/mst/mt0_pci_cr0'
 
     @mock.patch('sonic_platform.component.subprocess.check_call')

--- a/platform/mellanox/mlnx-platform-api/tests/test_component.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_component.py
@@ -1,6 +1,7 @@
 #
-# Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES.
-# Apache-2.0
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/platform/nvidia-bluefield/installer/install.sh.j2
+++ b/platform/nvidia-bluefield/installer/install.sh.j2
@@ -253,13 +253,13 @@ if [[ $SKIP_FIRMWARE_UPGRADE != "true" ]]; then
 		bfb_pre_fw_install
 	fi
 
-	ex $sonic_fs_mountpoint/usr/bin/mlnx-fw-upgrade.sh -v --no-mst
+	ex $sonic_fs_mountpoint/usr/bin/mlnx-fw-upgrade.sh -v
 	if [[ $? != 0 ]]; then
 		log "ERROR: FW update failed"
 	fi
 
 	if [[ $FORCE_FW_CONFIG_RESET == "true" ]]; then
-		ex $sonic_fs_mountpoint/usr/bin/mlnx-fw-upgrade.sh -v -r --no-mst
+		ex $sonic_fs_mountpoint/usr/bin/mlnx-fw-upgrade.sh -v -r
 	fi
 
 	ex umount $sonic_fs_mountpoint


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The mst driver is redundant as most of the operations can be done without starting and stopping of this driver with the pci id instead, the mst driver start causes some driver issues in kernel code during config reload and DPU startup in smartswitch platforms, so it is removed.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
remove mst restart in mlnx-fw-upgrade.sh file
Add it for DPU FPGA upgrade which increases degradation if we dont start mst

#### How to verify it
perform mst upgrade and check time for installation, and DPU_FPGA fwutil test.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

