### PR TITLE
[DPU] Create bash session on failure of firmware upgrade

### DIFF
--- a/platform/nvidia-bluefield/installer/install.sh.j2
+++ b/platform/nvidia-bluefield/installer/install.sh.j2
@@ -115,6 +115,19 @@ ex() {
     fi
 }
 
+# Run command like ex(); on failure start an interactive bash session for debugging
+ex_or_bash_session() {
+    echo "Executing command: $@" > /dev/ttyAMA0
+    local rc=0
+    $@ 2>&1 > /dev/ttyAMA0
+    rc=$?
+    if [[ $rc -ne 0 ]]; then
+        echo "RC: $rc" > /dev/ttyAMA0
+        log "Command failed (exit $rc), starting debug bash session"
+        run_bash_session
+    fi
+}
+
 if (lspci -n -d 15b3: | grep -wq 'a2dc'); then
 	module=BF3
 	if [[ $DHCP_CLASS_ID != "" ]]; then
@@ -247,10 +260,10 @@ if [[ $SKIP_FIRMWARE_UPGRADE != "true" ]]; then
 	fi
 
 	ex chroot $sonic_fs_mountpoint mst start
-	ex chroot $sonic_fs_mountpoint /usr/local/bin/mlnx-fw-manager --nosyslog --verbose
+	ex_or_bash_session chroot $sonic_fs_mountpoint /usr/local/bin/mlnx-fw-manager --nosyslog --verbose
 
 	if [[ $FORCE_FW_CONFIG_RESET == "true" ]]; then
-		ex chroot $sonic_fs_mountpoint /usr/local/bin/mlnx-fw-manager --reset --nosyslog --verbose
+		ex_or_bash_session chroot $sonic_fs_mountpoint /usr/local/bin/mlnx-fw-manager --reset --nosyslog --verbose
 	fi
 
 	ex umount $sonic_fs_mountpoint/host


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

